### PR TITLE
Bump version to 0.2026.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: snafun
 Type: Package
 Title: Bringing more fun to Social Network Analysis 
-Version: 0.2026.0
+Version: 0.2026.1
 Authors@R:
 	c(person(given = "Roger",
 					family = "Leenders",


### PR DESCRIPTION
Marks the release carrying this session's fixes (restored base-generic exports, extract_vertex_ids(), the stat_ef_int() inherits() fix, the deterministic one-predictor qapspp resolution, and the R-CMD-check workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)