### PR TITLE
Add R-CMD-check status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # SNAfun
+
+<!-- badges: start -->
+[![R-CMD-check](https://github.com/SNAnalyst/SNAfun/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SNAnalyst/SNAfun/actions/workflows/R-CMD-check.yaml)
+<!-- badges: end -->
+
 FUNctions to enjoy alongside the SNA4DS course
 
 The following API is used:


### PR DESCRIPTION
Shows main's CI status at a glance on the repo homepage and links to the Actions tab. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)