### PR TITLE
Add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Store and check out these text files with LF line endings on every platform.
+# roxygen2 regenerates NAMESPACE and man/*.Rd with LF, so without this a Windows
+# checkout (core.autocrlf=true) turns them CRLF and git then reports every
+# regenerated file as modified even when nothing changed.
+NAMESPACE   text eol=lf
+DESCRIPTION text eol=lf
+*.R    text eol=lf
+*.Rd   text eol=lf
+*.Rmd  text eol=lf
+*.md   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+
+# Binary files: never convert line endings.
+*.png   binary
+*.jpg   binary
+*.pdf   binary
+*.rda   binary
+*.rds   binary
+*.RData binary
+*.woff2 binary
+*.ttf   binary


### PR DESCRIPTION
Stops roxygen2-regenerated files (NAMESPACE, man/*.Rd) from showing as modified on Windows checkouts due to CRLF conversion. Repo content already stored as LF, so no renormalization churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)