### PR TITLE
Drop the sna4tutti dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,11 +33,9 @@ Imports:
 	spdep (>= 1.2-8),
 	usethis
 Remotes:
-	github::SNAnalyst/SNA4DSData,
-	github::SNAnalyst/sna4tutti
+	github::SNAnalyst/SNA4DSData
 Suggests:
 	SNA4DSData,
-	sna4tutti,
 	numDeriv,
 	tinytest,
 	gt, 

--- a/inst/tinytest/test_add_vertex_attributes.R
+++ b/inst/tinytest/test_add_vertex_attributes.R
@@ -145,11 +145,13 @@ rm(g, g1, mat)
 
 
 ## check that previous vertex attrs remain after adding new ones
-# sna4tutti is a Suggests, and flomar_network is one of its internal objects, so
-# guard the block rather than let the whole test file die where the package is
-# not installed.
-if (requireNamespace("sna4tutti", quietly = TRUE)) {
-  flomar_network <- sna4tutti:::flomar_network
+# The Florentine marriage network (Padgett), with its Wealth / NumberPriorates /
+# NumberTies vertex attributes. It lives in SNA4DSData (a Suggests) as an igraph;
+# convert it to a network object, which is what this block exercises. Guard the
+# block so the test file does not die where SNA4DSData is not installed.
+if (requireNamespace("SNA4DSData", quietly = TRUE)) {
+  data(florentine, package = "SNA4DSData")
+  flomar_network <- snafun::to_network(florentine$flomarriage)
 
   atts <- snafun::extract_all_vertex_attributes(flomar_network)
   # exclude the names and Wealth attrs
@@ -170,7 +172,7 @@ if (requireNamespace("sna4tutti", quietly = TRUE)) {
 
   rm(g, flomar_network, atts)
 } else {
-  message("test_add_vertex_attributes.R: sna4tutti not installed; ",
+  message("test_add_vertex_attributes.R: SNA4DSData not installed; ",
           "skipping the flomar_network block")
 }
 


### PR DESCRIPTION
sna4tutti (a GitHub-only Remote + Suggests) was used in one place: a test reached into `sna4tutti:::flomar_network`, a single internal dataset. That is the Padgett Florentine marriage network -- the same data as `florentine$flomarriage` in SNA4DSData (already a Suggests), differing only in class. Source it from SNA4DSData via `snafun::to_network()` instead. Behaviour-preserving: 47 assertions, 0 failures. Removes a GitHub-only remote without adding anything new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)