### PR TITLE
Move usethis and desc from Imports to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,19 +24,19 @@ Imports:
 	sna (>= 2.7),
 	utils,
 	btergm (>= 1.10.6),
-	desc,
 	ergm (>= 4.2.2),
 	igraph (>= 2.0.3),
 	network (>= 1.17.2),
 	networkDynamic (>= 0.11.2),
 	spatialreg (>= 1.2-9),
-	spdep (>= 1.2-8),
-	usethis
+	spdep (>= 1.2-8)
 Remotes:
 	github::SNAnalyst/SNA4DSData
 Suggests:
 	SNA4DSData,
 	numDeriv,
+	usethis,
+	desc,
 	tinytest,
 	gt,
 	htmltools,

--- a/R/util.R
+++ b/R/util.R
@@ -23,6 +23,15 @@
 #' @keywords internal
 save_internal_data <- function(..., overwrite_vars = FALSE, overwrite = FALSE,
                                 compress = "bzip2", version = 2) {
+  # usethis and desc are Suggests, needed only by this development helper and the
+  # internal functions it calls (all of which are reached only from here). Guard
+  # the single entry point rather than every call site.
+  if (!requireNamespace("usethis", quietly = TRUE) ||
+      !requireNamespace("desc", quietly = TRUE)) {
+    stop("save_internal_data() requires the 'usethis' and 'desc' packages. ",
+         "Install them, or use usethis::use_data(internal = TRUE) instead.",
+         call. = FALSE)
+  }
   check_is_package("use_data()")
   objs <- get_objs_from_dots(dots(...))
   use_dependency("R", "depends", "2.10")


### PR DESCRIPTION
usethis (heavy) and desc are used only by the unexported dev helper save_internal_data() and its internal helper cluster. Verified exhaustively: all 24 usethis:: and 5 desc:: calls in R/ are in util.R's cluster, reachable only from save_internal_data, which is @keywords internal and called by nothing in R/, vignettes, tests or inst. No user-facing or runtime code touches them, so regular users (and IT installing without Suggests) never need them. Move both to Suggests; guard the entry point with a clear message. R CMD check --as-cran clean (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)