### PR TITLE
Bump version to 0.2026.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: snafun
 Type: Package
 Title: Bringing more fun to Social Network Analysis 
-Version: 0.2026.1
+Version: 0.2026.2
 Authors@R:
 	c(person(given = "Roger",
 					family = "Leenders",


### PR DESCRIPTION
Marks the release carrying the dependency cleanup (sna4tutti and magrittr dropped, usethis/desc to Suggests, ergm import narrowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)